### PR TITLE
Add proxy location for C1 DRG.

### DIFF
--- a/proxy_features.json
+++ b/proxy_features.json
@@ -10,7 +10,7 @@
         "feature": "UBERON:0002834",
         "name": "cervical dorsal root ganglion",
         "proxies": [
-            "UBERON:0002838"
+            "UBERON:0002844"
         ]
     }
 ]

--- a/proxy_features.json
+++ b/proxy_features.json
@@ -5,5 +5,12 @@
         "proxies": [
             "UBERON:0003943"
         ]
+    },
+    {
+        "feature": "UBERON:0002834",
+        "name": "cervical dorsal root ganglion",
+        "proxies": [
+            "UBERON:0002838"
+        ]
     }
 ]


### PR DESCRIPTION
Cervical DRG datasets are now available, but the cervical DRG isn’t yet defined in the maps. Add a proxy node at the C1 DRG to represent it accurately.